### PR TITLE
add ES Lint, EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+
+[*.js]
+indent_size = 2
+charset = utf-8

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+    "extends": "airbnb",
+    "plugins": [
+        "react"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ npm install
 npm test
 ```
 
+## Linting
+
+```
+npm run lint
+```
+
 ## Run Locally
 
 ```

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "gulp serve",
     "dist": "gulp dist",
+    "lint": "eslint src/assets spec",
     "test": "karma start --single-run true"
   },
   "author": "",
@@ -15,6 +16,9 @@
     "babel-preset-react": "^6.3.13",
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",
+    "eslint": "^1.10.3",
+    "eslint-config-airbnb": "^4.0.0",
+    "eslint-plugin-react": "^3.16.1",
     "gulp": "^3.9.0",
     "gulp-babel": "^6.1.1",
     "gulp-concat": "^2.6.0",

--- a/spec/components/boxSpec.js
+++ b/spec/components/boxSpec.js
@@ -9,7 +9,7 @@ describe('Box', () => {
   beforeEach(() => {
     callbackSpy = jasmine.createSpy('callback');
     box = TestUtils.renderIntoDocument(
-      <Box name={'My Box'} duration={66000} paused onStart={callbackSpy}/>
+      <Box name={'My Box'} duration={66000} paused onStart={callbackSpy} />
     );
   });
 

--- a/spec/components/boxSpec.js
+++ b/spec/components/boxSpec.js
@@ -1,42 +1,44 @@
+/* eslint-env jasmine */
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 import Box from '../../src/assets/components/Box';
 
 describe('Box', () => {
-    let box;
-    function callback() {
-        console.log('pause please')
-    }
-    let callbackSpy;
+  let box;
+  let callbackSpy;
+  beforeEach(() => {
+    callbackSpy = jasmine.createSpy('callback');
+    box = TestUtils.renderIntoDocument(
+      <Box name={'My Box'} duration={66000} paused onStart={callbackSpy}/>
+    );
+  });
+
+  it('displays the name of the Box', () => {
+    expect(TestUtils.findRenderedDOMComponentWithTag(box, 'div').textContent).toContain('My Box');
+  });
+
+  it('formats the elapsed time as h:mm:ss', () => {
+    expect(TestUtils.findRenderedDOMComponentWithTag(box, 'div').textContent).toContain('0:01:06');
+  });
+
+  it('has a start button', () => {
+    expect(TestUtils.findRenderedDOMComponentWithTag(box, 'button').textContent).toEqual('Start');
+  });
+
+  it('has pause button when active', () => {
+    box = TestUtils.renderIntoDocument(
+      <Box name={'My Box'} duration={66000} paused={false} onStart={callbackSpy}/>
+    );
+    expect(TestUtils.findRenderedDOMComponentWithTag(box, 'button').textContent).toEqual('Pause');
+  });
+
+  describe('clicking start', () => {
     beforeEach(() => {
-        callbackSpy = jasmine.createSpy('callback');
-        box = TestUtils.renderIntoDocument(<Box name={'My Box'} duration={66000} paused={true} onStart={callbackSpy}/>);
+      TestUtils.Simulate.click(TestUtils.findRenderedDOMComponentWithTag(box, 'button'));
     });
 
-    it('displays the name of the Box', () => {
-        expect(TestUtils.findRenderedDOMComponentWithTag(box, 'div').textContent).toContain('My Box');
+    it('calls the callback function', () => {
+      expect(callbackSpy).toHaveBeenCalled();
     });
-
-    it('formats the elapsed time as h:mm:ss', () => {
-        expect(TestUtils.findRenderedDOMComponentWithTag(box, 'div').textContent).toContain('0:01:06');
-    });
-
-    it('has a start button', () => {
-        expect(TestUtils.findRenderedDOMComponentWithTag(box, 'button').textContent).toEqual('Start');
-    });
-
-    it('has pause button when paused', () => {
-        box = TestUtils.renderIntoDocument(<Box name={'My Box'} duration={66000} paused={false} onStart={callbackSpy}/>);
-        expect(TestUtils.findRenderedDOMComponentWithTag(box, 'button').textContent).toEqual('Pause');
-    });
-
-    describe('clicking start', () => {
-        beforeEach(() => {
-            TestUtils.Simulate.click(TestUtils.findRenderedDOMComponentWithTag(box, 'button'));
-        });
-
-        it('calls the callback function', () => {
-            expect(callbackSpy).toHaveBeenCalled();
-        });
-    });
+  });
 });

--- a/spec/components/mainSpec.js
+++ b/spec/components/mainSpec.js
@@ -1,54 +1,68 @@
-import React from 'react'
-import TestUtils from 'react-addons-test-utils'
-import Main from '../../src/assets/components/Main'
-import Box from '../../src/assets/components/Box'
+/* eslint-env jasmine */
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import Main from '../../src/assets/components/Main';
+import Box from '../../src/assets/components/Box';
 
 describe('Main', () => {
-    let main, box;
-    beforeEach(() => {
-        main = TestUtils.renderIntoDocument(<Main></Main>);
-        box = TestUtils.findRenderedComponentWithType(main, Box);
+  let main;
+  let box;
+  beforeEach(() => {
+    main = TestUtils.renderIntoDocument(<Main />);
+    box = TestUtils.findRenderedComponentWithType(main, Box);
+  });
+
+  it('contains a box', () => {
+    expect(box).toBeDefined();
+  });
+
+  it('passes props to box', () => {
+    expect(box.props.name).toEqual('I am a box');
+    expect(box.props.duration).toEqual(0);
+    expect(box.props.lastCheckedTime).toBeUndefined();
+    expect(box.props.paused).toBeTruthy();
+  });
+
+  it('starts out in a paused state', () => {
+    expect(main.state.paused).toBeTruthy();
+  });
+
+  it('clears timer on unmount', () => {
+    const clearIntervalSpy = spyOn(global, 'clearInterval');
+    main.componentWillUnmount();
+    expect(clearIntervalSpy).toHaveBeenCalled();
+  });
+
+  it('should not increase the duration if paused', () => {
+    jasmine.clock().install();
+    jasmine.clock().mockDate();
+    main = TestUtils.renderIntoDocument(<Main />);
+
+    jasmine.clock().tick(100);
+    expect(main.state.duration).toEqual(0);
+    jasmine.clock().tick(100);
+    expect(main.state.duration).toEqual(0);
+    jasmine.clock().uninstall();
+  });
+
+  describe('when clicking a button', () => {
+    it('changes state of paused', () => {
+      TestUtils.Simulate.click(TestUtils.findRenderedDOMComponentWithTag(main, 'button'));
+      expect(main.state.paused).toBeFalsy();
     });
 
-    it('contains a box', () => {
-        expect(box).toBeDefined();
+    it('starts a timer', () => {
+      jasmine.clock().install();
+      jasmine.clock().mockDate();
+      main = TestUtils.renderIntoDocument(<Main />);
+      TestUtils.Simulate.click(TestUtils.findRenderedDOMComponentWithTag(main, 'button'));
+      jasmine.clock().tick(100);
+      expect(main.state.duration).toEqual(0);
+      expect(main.state.lastCheckedTime).toEqual(Date.now());
+      jasmine.clock().tick(100);
+      expect(main.state.duration).toEqual(100);
+      expect(main.state.lastCheckedTime).toEqual(Date.now());
+      jasmine.clock().uninstall();
     });
-
-    it('passes props to box', () => {
-        expect(box.props.name).toEqual('I am a box');
-        expect(box.props.duration).toEqual(0);
-        expect(box.props.lastCheckedTime).toBeUndefined();
-        expect(box.props.paused).toBeTruthy();
-    });
-
-    it('has state of paused', () => {
-        expect(main.state.paused).toBeTruthy();
-    });
-
-    it('clears timer on unmount', () => {
-        const clearIntervalSpy = spyOn(global, 'clearInterval');
-        main.componentWillUnmount();
-        expect(clearIntervalSpy).toHaveBeenCalled();
-    });
-
-    describe('when clicking a button', () => {
-        it('changes state of paused', () => {
-            TestUtils.Simulate.click(TestUtils.findRenderedDOMComponentWithTag(main, 'button'));
-            expect(main.state.paused).toBeFalsy();
-        });
-
-        it('starts a timer', () => {
-            jasmine.clock().install();
-            jasmine.clock().mockDate();
-            main = TestUtils.renderIntoDocument(<Main></Main>);
-            TestUtils.Simulate.click(TestUtils.findRenderedDOMComponentWithTag(main, 'button'));
-            jasmine.clock().tick(100);
-            expect(main.state.duration).toEqual(0);
-            expect(main.state.lastCheckedTime).toEqual(Date.now());
-            jasmine.clock().tick(100);
-            expect(main.state.duration).toEqual(100);
-            expect(main.state.lastCheckedTime).toEqual(Date.now());
-            jasmine.clock().uninstall();
-        });
-    });
+  });
 });

--- a/src/assets/components/Box.js
+++ b/src/assets/components/Box.js
@@ -2,7 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import 'moment-duration-format';
 
-export default class Box extends React.Component {
+class Box extends React.Component {
   formattedTime() {
     return moment.duration(this.props.duration).format('h:mm:ss', { trim: false });
   }

--- a/src/assets/components/Box.js
+++ b/src/assets/components/Box.js
@@ -22,3 +22,12 @@ export default class Box extends React.Component {
     );
   }
 }
+
+Box.propTypes = {
+  paused: React.PropTypes.bool,
+  duration: React.PropTypes.number,
+  name: React.PropTypes.string,
+  onStart: React.PropTypes.func,
+};
+
+export default Box;

--- a/src/assets/components/Box.js
+++ b/src/assets/components/Box.js
@@ -2,27 +2,23 @@ import React from 'react';
 import moment from 'moment';
 import 'moment-duration-format';
 
-class Box extends React.Component {
-    constructor(props) {
-        super(props);
-    }
+export default class Box extends React.Component {
+  formattedTime() {
+    return moment.duration(this.props.duration).format('h:mm:ss', { trim: false });
+  }
 
-    formattedTime() {
-        return moment.duration(this.props.duration).format('h:mm:ss', {trim: false});
-    }
-
-    handlePause() {
-        this.props.onStart()
-    }
+  handlePause() {
+    this.props.onStart();
+  }
 
 
-    render() {
-        const pauseState = this.props.paused ? 'Start' : 'Pause';
-        return <div>
-            {this.props.name} {this.formattedTime()}
-            <button onClick={this.handlePause.bind(this)}>{pauseState}</button>
-        </div>;
-    }
+  render() {
+    const pauseState = this.props.paused ? 'Start' : 'Pause';
+    return (
+      <div>
+        {this.props.name} {this.formattedTime()}
+        <button onClick={this.handlePause.bind(this)}>{pauseState}</button>
+      </div>
+    );
+  }
 }
-
-export default Box;

--- a/src/assets/components/Main.js
+++ b/src/assets/components/Main.js
@@ -44,3 +44,7 @@ export default class Main extends React.Component {
     );
   }
 }
+
+Main.propTypes = {};
+
+export default Main;

--- a/src/assets/components/Main.js
+++ b/src/assets/components/Main.js
@@ -1,46 +1,46 @@
-import React from 'react'
-import Box from './Box'
+import React from 'react';
+import Box from './Box';
 
-class Main extends React.Component {
-    constructor() {
-        super();
-        let lastCheckedTime;
-        this.state = {name: 'I am a box', duration: 0, lastCheckedTime: lastCheckedTime, paused: true};
-    }
+export default class Main extends React.Component {
+  constructor() {
+    super();
+    this.state = { name: 'I am a box', duration: 0, lastCheckedTime: undefined, paused: true };
+  }
 
-    componentDidMount() {
-        this.startTimer();
-    }
+  componentDidMount() {
+    this.startTimer();
+  }
 
-    componentWillUnmount() {
-        clearInterval(this.intervalID);
-    }
+  componentWillUnmount() {
+    clearInterval(this.intervalID);
+  }
 
-    startTimer() {
-        this.intervalID = setInterval(this.incrementDurations.bind(this), 100);
-    }
+  startTimer() {
+    this.intervalID = setInterval(this.incrementDurations.bind(this), 100);
+  }
 
-    toggleActive() {
-        this.setState({paused: !this.state.paused});
-    }
+  toggleActive() {
+    this.setState({ paused: !this.state.paused });
+  }
 
-    incrementDurations() {
-        if (!this.state.paused) {
-            const now = new Date().getTime();
-            const lastCheckTime = this.state.lastCheckedTime || now;
-            const elapsed = now - lastCheckTime;
-            const duration = this.state.duration += elapsed;
-            this.setState({duration, lastCheckedTime: now})
-        }
+  incrementDurations() {
+    if (!this.state.paused) {
+      const now = Date.now();
+      const lastCheckedTime = this.state.lastCheckedTime || now;
+      const elapsed = now - lastCheckedTime;
+      const duration = this.state.duration += elapsed;
+      this.setState({ duration, lastCheckedTime: now });
     }
+  }
 
-    render() {
-        return <div>
-            <Box name={this.state.name} duration={this.state.duration}
-                paused={this.state.paused}
-                onStart={this.toggleActive.bind(this)}/>
-        </div>
-    }
+  render() {
+    return (
+      <div>
+        <Box name={this.state.name} duration={this.state.duration}
+          paused={this.state.paused}
+          onStart={this.toggleActive.bind(this)}
+        />
+      </div>
+    );
+  }
 }
-
-export default Main

--- a/src/assets/components/Main.js
+++ b/src/assets/components/Main.js
@@ -44,7 +44,3 @@ export default class Main extends React.Component {
     );
   }
 }
-
-Main.propTypes = {};
-
-export default Main;

--- a/src/assets/index.js
+++ b/src/assets/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Main from './components/Main'
+import Main from './components/Main';
 
 ReactDOM.render(<Main />, document.getElementById('app'));


### PR DESCRIPTION
- installs [es6 AirBnB style
  guide](https://github.com/airbnb/javascript), including React - run via
  `npm run lint`
- fixes most offending issues against style guide, but leaves a few TBD
  (not sure what we’d want to do about react/jsx-no-bind)
- sets spacing to 2 spaces, uses EditorConfig file to help editors use
  corresponding settings
